### PR TITLE
Use ssh private key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # docker-vboxwebsrv
+FORKED BY VEGARDSAGLIEN
+The fork makes the container use an ssh-key instead of asking for password, making it non-interactive.
 
 This is a minimal [docker](https://www.docker.io) image that allows you to connect to a computer running VirtualBox
 through SSH and expose its SOAP WebService (vboxwebsrv) on your machine.
@@ -10,20 +12,21 @@ docker image.
 
 ## Usage
 
-This docker image is available as a [trusted build on the docker index](https://index.docker.io/u/clue/vboxwebsrv/).
+This docker image is available as a [trusted build on the docker index](https://index.docker.io/u/vegardsaglien/vboxwebsrv/).
 Using this image for the first time will start a download automatically.
 Further runs will be immediate, as the image will be cached locally.
 
 The recommended way to run this container looks like this:
 
 ```bash
-$ docker run -it --name=vb1 clue/vboxwebsrv vbox@10.1.2.3
+$ docker run -d --name=vb1 -v /root/.ssh/id_rsa:/root/.ssh/id_rsa vegardsaglien/vboxwebsrv vbox@10.1.2.3
 ```
 
-This will start an interactive container that will establish a connection to the given host.
+This will start a container that will establish a connection to the given host.
 The host `10.1.2.3` is your computer that VirtualBox is installed on.
 
-To establish an encrypted SSH connection it will likely ask for your password for user `vbox`.
+To establish an encrypted SSH connection it will use the privatekey `id_rsa`.
+Make sure you can connect to the server with the given key before running the container. If it asks for password, you have done something wrong.
 This is the user that runs your virtual machines (VMs).
 
 Once connected, it will launch a temporary instance of the  `vboxwebsrv` program that comes with VirtualBox.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The host `10.1.2.3` is your computer that VirtualBox is installed on.
 
 To establish an encrypted SSH connection it will use the privatekey `id_rsa`.
 Make sure you can connect to the server with the given key before running the container. If it asks for password, you have done something wrong.
-This is the user that runs your virtual machines (VMs).
 
 Once connected, it will launch a temporary instance of the  `vboxwebsrv` program that comes with VirtualBox.
 This will be exposed through the SSH tunnel to your docker container and will terminate when your container

--- a/run.sh
+++ b/run.sh
@@ -7,5 +7,5 @@ if [[ "${PORT:-0}" = "0" ]]; then
   PORT=5678
 fi
 
-ssh -L 0.0.0.0:18083:localhost:$PORT $1 "killall vboxwebsrv; vboxwebsrv -p $PORT -A null"
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -L 0.0.0.0:18083:localhost:$PORT $1 "killall vboxwebsrv; vboxwebsrv -p $PORT -A null"
 


### PR DESCRIPTION
My fork allow the container to use SSH keys in order to authenticate.

It is using the flags _-o UserKnownHostsFile=/dev/null_ and -_o StrictHostKeyChecking=no_ when connecting using ssh, which disables the ECDSA key fingerprint warnings.

(The README.md file is obviously only forked for personal convenience, and should be changed to suit your needs)